### PR TITLE
fix: Correct selector value inconsistency in DKIM signing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ let private_key =
 let signer = SignerBuilder::new()
     .with_signed_headers(&["From", "Subject"])?
     .with_private_key(private_key)
-    .with_selector("2020")
+    .with_selector("2022")
     .with_logger(&logger)
     .with_signing_domain("example.com")
     .build()?;


### PR DESCRIPTION
This PR fixes an inconsistency in the DKIM signing example. The selector value in the `SignerBuilder` was set to `2020`, while the key file path and `opendkim-genkey` command used `2022`. This inconsistency could cause confusion or errors when following the example.

### Changes:
- Updated the selector value in the `SignerBuilder` from `2020` to `2022` to match the key file path (`./test/keys/2022.private`) and the `opendkim-genkey` command (`--selector=2022`).

### Why is this change necessary?
- The selector value must match the key file and the `opendkim-genkey` command for DKIM signing to work correctly.
- This fix ensures that the example is consistent and easy to follow.